### PR TITLE
Signals created during an update phase doesn't get updated

### DIFF
--- a/FRP/Elerea/Simple.hs
+++ b/FRP/Elerea/Simple.hs
@@ -137,13 +137,25 @@ start (SG gen) = do
   pool <- newIORef []
   S sample <- gen pool
   return $ do
-    let deref ptr = (fmap.fmap) ((,) ptr) (deRefWeak ptr)
     res <- sample
-    (ptrs,acts) <- unzip.catMaybes <$> (mapM deref =<< readIORef pool)
-    writeIORef pool ptrs
-    mapM_ fst acts
-    mapM_ snd acts
+    cleanup pool
     return res
+
+cleanup :: IORef UpdatePool -> IO ()
+cleanup pool =
+  let
+    deref ptr = (fmap.fmap) ((,) ptr) (deRefWeak ptr)
+    loop allPtrs final = do
+      (ptrs,acts) <- unzip.catMaybes <$> (mapM deref =<< readIORef pool)
+      if null acts
+        then do
+          final
+          writeIORef pool allPtrs
+        else do
+          writeIORef pool []
+          mapM_ fst acts
+          loop (ptrs++allPtrs) (final >> mapM_ snd acts)
+  in loop [] (return ())
 
 -- | Auxiliary function used by all the primitives that create a
 -- mutable variable.


### PR DESCRIPTION
Hi. I found a bug while playing with elerea. If a signal is created during an update phase, it doesn't get updated until the next iteration. The following code demonstrates the problem: it should print "0 2" but it prints "0 1". The reason is that the signal named "problem" doesn't get updated during the first iteration.

``` haskell
import Control.Applicative
import Control.Monad
import FRP.Elerea.Simple

andthen :: a -> a -> SignalGen (Signal a)
andthen x y = delay x (pure y)

zero :: Signal Int
zero = pure 0

makeProblem :: SignalGen (Signal Int)
makeProblem = do
  problem <- 1 `andthen` 2
  return problem

test :: SignalGen (Signal Int)
test = do
  dyn <- generator $ pure makeProblem
  prevDyn <- delay zero dyn
  sig <- zero `andthen` join prevDyn
  return $ join sig

main = do
  sample <- start test
  sample >>= print
  sample >>= print
```
