### PR TITLE
externalMulti is not thread-safe

### DIFF
--- a/FRP/Elerea/Clocked.hs
+++ b/FRP/Elerea/Clocked.hs
@@ -530,10 +530,9 @@ externalMulti :: IO (SignalGen (Signal [a]), a -> IO ()) -- ^ a generator for th
 externalMulti = do
     var <- newMVar []
     return (SG $ \gpool _pool -> do
-                 let sig = S $ readMVar var
-                 update <- mkWeak sig (return (),takeMVar var >> putMVar var []) Nothing
-                 modifyIORef gpool (USig update:)
-                 return sig
+                 ref <- newIORef (Ready undefined)
+                 let sample = modifyMVar var $ \list -> memoise ref list >> return ([], list)
+                 addSignal (const sample) (const (() <$ sample)) ref gpool
            ,\val -> do
                  vals <- takeMVar var
                  putMVar var (val:vals)

--- a/FRP/Elerea/Param.hs
+++ b/FRP/Elerea/Param.hs
@@ -434,10 +434,9 @@ externalMulti :: IO (SignalGen p (Signal [a]), a -> IO ()) -- ^ a generator for 
 externalMulti = do
   var <- newMVar []
   return (SG $ \pool _ -> do
-             let sig = S $ readMVar var
-             update <- mkWeak sig (return (),takeMVar var >> putMVar var []) Nothing
-             modifyIORef pool (update:)
-             return sig
+             ref <- newIORef (Ready undefined)
+             let sample = modifyMVar var $ \list -> memoise ref list >> return ([], list)
+             addSignal (const sample) (const (() <$ sample)) ref pool
          ,\val -> do vals <- takeMVar var
                      putMVar var (val:vals)
          )


### PR DESCRIPTION
The implementation of externalMulti uses an MVar but does not work correctly when the sink function is called from a different thread. When the signal gets updated, it discards any data that have been sent since the last read to the signal. This can be observed as dropped events. This commit makes it thread-safe.
