### PR TITLE
Add MonadIO instance for SignalGen

### DIFF
--- a/FRP/Elerea/Clocked.hs
+++ b/FRP/Elerea/Clocked.hs
@@ -99,6 +99,7 @@ import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.Fix
+import Control.Monad.IO.Class
 import Data.IORef
 import Data.Maybe
 import Prelude hiding (until)
@@ -176,6 +177,9 @@ instance Monad SignalGen where
 
 instance MonadFix SignalGen where
     mfix f = SG $ \p1 p2 -> mfix $ \x -> unSG (f x) p1 p2
+
+instance MonadIO SignalGen where
+    liftIO = execute
 
 getUpdate :: Update -> IO (Maybe (Update, UpdateAction))
 getUpdate upd@(USig ptr) = (fmap.fmap) ((,) upd) (deRefWeak ptr)

--- a/FRP/Elerea/Param.hs
+++ b/FRP/Elerea/Param.hs
@@ -48,6 +48,7 @@ import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.Fix
+import Control.Monad.IO.Class
 import Data.IORef
 import Data.Maybe
 import Prelude hiding (until)
@@ -117,6 +118,9 @@ instance Monad (SignalGen p) where
 
 instance MonadFix (SignalGen p) where
   mfix f = SG $ \p i -> mfix $ \x -> unSG (f x) p i
+
+instance MonadIO (SignalGen p) where
+  liftIO = execute
 
 -- | Embedding a signal into an 'IO' environment.  Repeated calls to
 -- the computation returned cause the whole network to be updated, and

--- a/FRP/Elerea/Simple.hs
+++ b/FRP/Elerea/Simple.hs
@@ -44,6 +44,7 @@ import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.Fix
+import Control.Monad.IO.Class
 import Data.IORef
 import Data.Maybe
 import Prelude hiding (until)
@@ -111,6 +112,9 @@ instance Monad SignalGen where
 
 instance MonadFix SignalGen where
     mfix f = SG $ \p -> mfix $ \x -> unSG (f x) p
+
+instance MonadIO SignalGen where
+    liftIO = execute
 
 -- | Embedding a signal into an 'IO' environment.  Repeated calls to
 -- the computation returned cause the whole network to be updated, and

--- a/elerea.cabal
+++ b/elerea.cabal
@@ -57,5 +57,5 @@ Library
     FRP.Elerea.Param
     FRP.Elerea.Clocked
 
-  Build-Depends:       base >= 4 && < 5, containers
+  Build-Depends:       base >= 4 && < 5, containers, transformers
   ghc-options:         -Wall -O2


### PR DESCRIPTION
Is there any reason why `SignalGen` isn't an instance of `MonadIO`? `execute` seems to satisfy the `MonadIO` laws:

```
1) execute . return = return

    execute . return
    = \x -> execute (return x)
    = \x -> SG (\_ -> return x)

    return
    = \x -> SG (\_ -> return x)

2) execute (m >>= f) = execute m >>= execute . f

    execute (m >>= f)
    = SG (\_ -> m >>= f)

    execute m >>= execute . f
    = SG (\_ -> m) >>= execute . f
    = SG (\p -> (\_ -> m) p >>= \x -> unSG (execute (f x)) p)
    = SG (\p -> m >>= \x -> unSG (execute (f x)) p)
    = SG (\p -> m >>= \x -> unSG (SG (\_ -> f x)) p)
    = SG (\p -> m >>= \x -> (\_ -> f x) p)
    = SG (\_ -> m >>= \x -> f x)
    = SG (\_ -> m >>= f)
```

I think the same applies to `FRP.Elerea.Clocked` and `FRP.Elerea.Param`.
