### PR TITLE
Add MonadBase instance for SignalGen

### DIFF
--- a/FRP/Elerea/Clocked.hs
+++ b/FRP/Elerea/Clocked.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 {-|
 
@@ -98,6 +99,7 @@ module FRP.Elerea.Clocked
 import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
+import Control.Monad.Base
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Data.IORef
@@ -180,6 +182,9 @@ instance MonadFix SignalGen where
 
 instance MonadIO SignalGen where
     liftIO = execute
+
+instance MonadBase SignalGen SignalGen where
+    liftBase = id
 
 getUpdate :: Update -> IO (Maybe (Update, UpdateAction))
 getUpdate upd@(USig ptr) = (fmap.fmap) ((,) upd) (deRefWeak ptr)

--- a/FRP/Elerea/Param.hs
+++ b/FRP/Elerea/Param.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 {-|
 
@@ -47,6 +48,7 @@ module FRP.Elerea.Param
 import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
+import Control.Monad.Base
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Data.IORef
@@ -121,6 +123,9 @@ instance MonadFix (SignalGen p) where
 
 instance MonadIO (SignalGen p) where
   liftIO = execute
+
+instance MonadBase (SignalGen p) (SignalGen p) where
+  liftBase = id
 
 -- | Embedding a signal into an 'IO' environment.  Repeated calls to
 -- the computation returned cause the whole network to be updated, and

--- a/FRP/Elerea/Simple.hs
+++ b/FRP/Elerea/Simple.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 {-|
 
@@ -43,6 +44,7 @@ module FRP.Elerea.Simple
 import Control.Applicative
 import Control.Concurrent.MVar
 import Control.Monad
+import Control.Monad.Base
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Data.IORef
@@ -115,6 +117,9 @@ instance MonadFix SignalGen where
 
 instance MonadIO SignalGen where
     liftIO = execute
+
+instance MonadBase SignalGen SignalGen where
+    liftBase = id
 
 -- | Embedding a signal into an 'IO' environment.  Repeated calls to
 -- the computation returned cause the whole network to be updated, and

--- a/elerea.cabal
+++ b/elerea.cabal
@@ -57,5 +57,5 @@ Library
     FRP.Elerea.Param
     FRP.Elerea.Clocked
 
-  Build-Depends:       base >= 4 && < 5, containers, transformers
+  Build-Depends:       base >= 4 && < 5, containers, transformers, transformers-base
   ghc-options:         -Wall -O2


### PR DESCRIPTION
If you put `SignalGen` at the bottom of monad transformer stacks, you'd find it convenient if elerea had something like `liftSGen :: MonadSignalGen m => SignalGen a -> m a`. With this patch, we can use `liftBase` for this purpose. Here is a small example:

``` haskell
import Control.Applicative
import Control.Monad.Base
import Control.Monad.Reader
import FRP.Elerea.Simple

newtype MyGenT m a = MyGenT { runMyGenT :: ReaderT Int m a }
  deriving (Functor, Applicative, Monad, MonadTrans, MonadBase b, MonadReader Int)

type MyGen = MyGenT SignalGen

foo :: MyGen (Signal Int)
foo = do
  n <- ask
  liftBase $ stateful n (+1)
```
